### PR TITLE
That's... that's not how contexts work. Do it the smart way

### DIFF
--- a/fs/command_test.go
+++ b/fs/command_test.go
@@ -1,15 +1,17 @@
 package fs
 
 import (
+	"context"
 	"testing"
 	"time"
 )
 
 func TestCommands(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
 	reqs := make(chan string)
-	ctl := &testctrl{}
+	ctl := &testctrl{cancel}
 
-	c, err := MockCtlFile(ctl, reqs, "test", false)
+	c, err := MockCtlFile(ctx, ctl, reqs, "test", false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/fs/ctl_test.go
+++ b/fs/ctl_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 type testctrl struct {
@@ -99,6 +100,28 @@ func TestWriters(t *testing.T) {
 		mw.Close()
 		reqs <- "test quit"
 	}()
+
+	if e := c.Listen(); e != nil {
+		t.Error(e)
+	}
+}
+
+func TestCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reqs := make(chan string)
+	ctl := &testctrl{cancel}
+
+	c, err := MockCtlFile(ctx, ctl, reqs, "test", false)
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer c.Cleanup()
+
+	time.AfterFunc(time.Second*2, func() {
+		cancel()
+	})
 
 	if e := c.Listen(); e != nil {
 		t.Error(e)


### PR DESCRIPTION
Initially, Start returned a context and I was attempting to call a cancel on it. Services wouldn't exit correctly; this reverses the logic and allows you to cancel at any point correctly through the context; or through the ctl file with a "<service> quit" message