### PR TITLE
Commandfix

### DIFF
--- a/fs/command.go
+++ b/fs/command.go
@@ -35,12 +35,11 @@ type Command struct {
 func FindCommands(b []byte) ([]*Command, error) {
 	var cmdlist []*Command
 
-	cl, err := command.Parse(b)
+	cl, err := command.ParseCtlFile(b)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println("out of parse")
 	for _, cmd := range cl {
 		c := &Command{
 			Name:        cmd.Name,
@@ -60,9 +59,9 @@ func FindCommands(b []byte) ([]*Command, error) {
 func (c *Command) String() string {
 	args := strings.Join(c.Args, " ")
 	if c.From != "" {
-		return fmt.Sprintf("%s %s %s\n", c.Name, c.From, args)
+		return fmt.Sprintf("%s \"%s\" \"%s\"\n", c.Name, c.From, args)
 	}
-	return fmt.Sprintf("%s %s\n", c.Name, args)
+	return fmt.Sprintf("%s \"%s\"\n", c.Name, args)
 }
 
 // Bytes - Return a byte representation of a command

--- a/fs/command_test.go
+++ b/fs/command_test.go
@@ -22,16 +22,17 @@ func TestCommands(t *testing.T) {
 	cmdlist = append(cmdlist, testMakeCmd("baz", []string{"<2>", "<1>"}, ActionGroup, []string{}))
 	cmdlist = append(cmdlist, testMakeCmd("banana", []string{}, MediaGroup, []string{}))
 	cmdlist = append(cmdlist, testMakeCmd("nocomm", []string{}, ActionGroup, []string{"yacomm", "maybecomm"}))
+	cmdlist = append(cmdlist, testMakeCmd("quit", nil, DefaultGroup, nil))
 
 	if e := c.SetCommands(cmdlist...); e != nil {
 		t.Error(e)
 	}
 
 	time.AfterFunc(time.Second*1, func() {
-		reqs <- "foo current test"
-		reqs <- "bar current test this"
-		reqs <- "baz current test this"
-		reqs <- "nocomm current jump up jump up and get down"
+		reqs <- `foo "current" "test"`
+		reqs <- `bar current test this`
+		reqs <- `baz "current" "test" "this"`
+		reqs <- `nocomm "current" jump up jump up and get down`
 		reqs <- "foo current too many args should log error"
 		reqs <- "banana current"
 		reqs <- "test quit"

--- a/fs/command_test.go
+++ b/fs/command_test.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"testing"
-	"time"
 )
 
 func TestCommands(t *testing.T) {
@@ -11,36 +10,19 @@ func TestCommands(t *testing.T) {
 	reqs := make(chan string)
 	ctl := &testctrl{cancel}
 
-	c, err := MockCtlFile(ctx, ctl, reqs, "test", false)
+	c, err := MockCtlFile(ctx, ctl, reqs, "cmdtest", false)
 	if err != nil {
 		t.Error(err)
 	}
 
-	var cmdlist []*Command
-	cmdlist = append(cmdlist, testMakeCmd("foo", []string{"<1>"}, ActionGroup, []string{}))
-	cmdlist = append(cmdlist, testMakeCmd("bar", []string{"<1>", "<2>"}, MediaGroup, []string{}))
-	cmdlist = append(cmdlist, testMakeCmd("baz", []string{"<2>", "<1>"}, ActionGroup, []string{}))
-	cmdlist = append(cmdlist, testMakeCmd("banana", []string{}, MediaGroup, []string{}))
-	cmdlist = append(cmdlist, testMakeCmd("nocomm", []string{}, ActionGroup, []string{"yacomm", "maybecomm"}))
-	cmdlist = append(cmdlist, testMakeCmd("quit", nil, DefaultGroup, nil))
+	var cmdlist2 []*Command
+	cmdlist2 = append(cmdlist2, testMakeCmd("foo", []string{"<1>"}, ActionGroup, []string{}))
+	cmdlist2 = append(cmdlist2, testMakeCmd("bar", []string{"<1>", "<2>"}, MediaGroup, []string{}))
+	cmdlist2 = append(cmdlist2, testMakeCmd("baz", []string{"<2>", "<1>"}, ActionGroup, []string{}))
+	cmdlist2 = append(cmdlist2, testMakeCmd("banana", []string{}, MediaGroup, []string{}))
+	cmdlist2 = append(cmdlist2, testMakeCmd("nocomm", []string{}, ActionGroup, []string{"yacomm", "maybecomm"}))
 
-	if e := c.SetCommands(cmdlist...); e != nil {
-		t.Error(e)
-	}
-
-	time.AfterFunc(time.Second*1, func() {
-		reqs <- `foo "current" "test"`
-		reqs <- `bar current test this`
-		reqs <- `baz "current" "test" "this"`
-		reqs <- `nocomm "current" jump up jump up and get down`
-		reqs <- "foo current too many args should log error"
-		reqs <- "banana current"
-		reqs <- "test quit"
-	})
-
-	defer c.Cleanup()
-
-	if e := c.Listen(); e != nil {
+	if e := c.SetCommands(cmdlist2...); e != nil {
 		t.Error(e)
 	}
 }

--- a/fs/ctl_test.go
+++ b/fs/ctl_test.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"context"
 	"testing"
-	"time"
 )
 
 type testctrl struct {
@@ -55,28 +54,6 @@ func TestWriters(t *testing.T) {
 		mw.Close()
 		reqs <- "test quit"
 	}()
-
-	if e := c.Listen(); e != nil {
-		t.Error(e)
-	}
-}
-
-func TestCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	reqs := make(chan string)
-	ctl := &testctrl{cancel}
-
-	c, err := MockCtlFile(ctx, ctl, reqs, "test", false)
-	if err != nil {
-		t.Error(err)
-	}
-
-	defer c.Cleanup()
-
-	time.AfterFunc(time.Second*1, func() {
-		cancel()
-	})
 
 	if e := c.Listen(); e != nil {
 		t.Error(e)

--- a/fs/ctl_test.go
+++ b/fs/ctl_test.go
@@ -10,67 +10,22 @@ type testctrl struct {
 	cancel context.CancelFunc
 }
 
-func (c *testctrl) Open(ctl *Control, buf string) error {
-	return ctl.CreateBuffer(buf, "test")
-}
-
-func (c *testctrl) Close(ctl *Control, buf string) error {
-	return ctl.DeleteBuffer(buf, "test")
-}
-
-func (c *testctrl) Link(ctl *Control, to, from string) error {
-	if e := ctl.DeleteBuffer(from, "test"); e != nil {
-		return e
+func (c *testctrl) Run(ctrl *Control, cmd *Command) error {
+	switch cmd.Name {
+	case "open":
+	case "close":
+	case "buffer":
+	case "link":
+	case "reload":
+	case "restart":
+	default:
 	}
 
-	return ctl.CreateBuffer(to, "test")
-}
-
-func (c *testctrl) Default(ctl *Control, cmd *Command) error {
-	return nil
-}
-
-func (c *testctrl) Refresh(ctl *Control) error {
-	return nil
-}
-
-func (c *testctrl) Restart(ctl *Control) error {
 	return nil
 }
 
 func (c *testctrl) Quit() {
 	c.cancel()
-}
-
-func sendctl(reqs chan string) {
-	// Commands are sent with the current buffer for context
-	reqs <- "open current foo"
-	reqs <- "open current bar"
-	reqs <- "link current bar baz"
-	reqs <- "gibberish"
-	reqs <- "close current baz"
-	reqs <- "test quit"
-}
-
-func TestCtl(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	reqs := make(chan string)
-	ctl := &testctrl{cancel}
-
-	c, err := MockCtlFile(ctx, ctl, reqs, "test", false)
-	if err != nil {
-		t.Error(err)
-	}
-
-	c.SetCommands()
-	defer c.Cleanup()
-
-	go sendctl(reqs)
-
-	if e := c.Listen(); e != nil {
-		t.Error(e)
-	}
 }
 
 func TestWriters(t *testing.T) {
@@ -119,7 +74,7 @@ func TestCancel(t *testing.T) {
 
 	defer c.Cleanup()
 
-	time.AfterFunc(time.Second*2, func() {
+	time.AfterFunc(time.Second*1, func() {
 		cancel()
 	})
 

--- a/fs/internal/command/lexer.go
+++ b/fs/internal/command/lexer.go
@@ -1,0 +1,90 @@
+package command
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+type stateFn func(*lexer) stateFn
+
+// Lexer allows tokenizing of altid-flavored markdown for client-side parsers
+type lexer struct {
+	src     []byte
+	start   int
+	width   int
+	pos     int
+	items   chan item
+	state   stateFn
+	heading ComGroup
+}
+
+type item struct {
+	itemType byte
+	data     []byte
+}
+
+func (l *lexer) next() item {
+	for {
+		select {
+		case item := <-l.items:
+			return item
+		default:
+			l.state = l.state(l)
+		}
+	}
+}
+
+func (l *lexer) nextChar() byte {
+	if l.pos >= len(l.src) {
+		l.width = 0
+		return parserEOF
+	}
+
+	rune, width := utf8.DecodeRune(l.src[l.pos:])
+	l.width = width
+	l.pos += l.width
+
+	return byte(rune)
+}
+
+func (l *lexer) emit(t byte) {
+	l.items <- item{
+		t,
+		l.src[l.start:l.pos],
+	}
+
+	l.start = l.pos
+}
+
+func (l *lexer) peek() byte {
+	rune := l.nextChar()
+	l.backup()
+
+	return rune
+}
+
+func (l *lexer) ignore() {
+	l.start = l.pos
+}
+
+func (l *lexer) backup() {
+	l.pos -= l.width
+}
+
+func (l *lexer) accept(valid string) bool {
+	if strings.IndexByte(valid, l.nextChar()) >= 0 {
+		return true
+	}
+
+	l.backup()
+	return false
+}
+
+func (l *lexer) acceptRun(valid string) {
+	for {
+		if strings.IndexByte(valid, l.nextChar()) < 0 {
+			l.backup()
+			return
+		}
+	}
+}

--- a/fs/internal/command/parsecmd.go
+++ b/fs/internal/command/parsecmd.go
@@ -1,0 +1,159 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// Don't override our other values
+	cmdName byte = iota + 2
+	cmdFrom
+	cmdArgs
+	cmdErr
+)
+
+func parseCmd(cmd string) (string, string, []string, error) {
+	var name, from string
+	var args []string
+
+	l := &lexer{
+		src:   []byte(cmd),
+		items: make(chan item, 2),
+		state: parseCmdName,
+	}
+
+	for {
+		i := l.next()
+		switch i.itemType {
+		case cmdErr:
+			return "", "", nil, fmt.Errorf("%s", i.data)
+		case cmdName:
+			name = string(i.data)
+		case cmdFrom:
+			from = string(i.data)
+		case cmdArgs:
+			args = strings.Fields(string(i.data))
+		case parserEOF:
+			// Clean up, possible on /quit, etc
+			if from != "" && len(args) == 0 {
+				args = strings.Fields(from)
+				from = ""
+			}
+
+			return name, from, args, nil
+		}
+	}
+}
+
+func parseCmdName(l *lexer) stateFn {
+	for {
+		c := l.peek()
+
+		if strings.IndexByte(" \t", c) >= 0 {
+			if l.pos > l.start {
+				l.emit(cmdName)
+			}
+		}
+
+		if c == parserEOF {
+			l.emit(cmdName)
+		}
+
+		switch l.nextChar() {
+		case parserEOF:
+			l.emit(parserEOF)
+			return nil
+		case ' ', '\t':
+			l.acceptRun("\t ")
+			l.ignore()
+			return parseCmdFrom
+		}
+	}
+}
+
+func parseCmdFrom(l *lexer) stateFn {
+	var inCompound bool
+
+	for {
+		switch inCompound {
+		case true:
+			if l.peek() == '"' {
+				l.emit(cmdFrom)
+			}
+
+			switch l.nextChar() {
+			case parserEOF:
+				l.emit(parserEOF)
+				return nil
+			case '"':
+				// Careful we don't eat the next tag
+				l.accept("\"")
+				l.accept(" ")
+				l.ignore()
+				return parseCmdArgs
+			}
+		case false:
+			c := l.peek()
+
+			if strings.IndexByte(" \t\n", c) >= 0 {
+				if l.pos > l.start {
+					l.emit(cmdFrom)
+				}
+			}
+
+			// Catch early EOF here
+			if c == parserEOF {
+				l.emit(cmdFrom)
+			}
+
+			switch l.nextChar() {
+			case parserEOF, '\n':
+				l.emit(parserEOF)
+				return nil
+			case '"':
+				l.accept("\"")
+				l.ignore()
+				inCompound = true
+			case ' ', '\t':
+				l.acceptRun("\t ")
+				l.ignore()
+				return parseCmdArgs
+			}
+		}
+	}
+}
+
+func parseCmdArgs(l *lexer) stateFn {
+	var inCompound bool
+
+	for {
+		switch inCompound {
+		case true:
+			if l.peek() == '"' {
+				l.emit(cmdArgs)
+			}
+
+			switch l.nextChar() {
+			case parserEOF, '"':
+				l.emit(parserEOF)
+				return nil
+			}
+		case false:
+			if l.peek() == '\n' {
+				l.emit(cmdArgs)
+			}
+
+			// If we don't find an opening quotation, send the whole string
+			switch l.nextChar() {
+			case parserEOF, '\n':
+				l.emit(parserEOF)
+				return nil
+			case '"':
+				l.accept("\"")
+				l.ignore()
+				inCompound = true
+			}
+		}
+	}
+}

--- a/fs/internal/command/parsecmd_test.go
+++ b/fs/internal/command/parsecmd_test.go
@@ -1,0 +1,49 @@
+package command
+
+import (
+	"testing"
+)
+
+var cmdlist = []*Command{
+	{
+		Name:        "link",
+		Args:        []string{"<to>", "<from>"},
+		Description: "Tests",
+		Alias:       []string{"foo", "bar"},
+		Heading:     DefaultGroup,
+	},
+	{
+		Name: "quit",
+	},
+}
+
+func TestParseCmd(t *testing.T) {
+
+	cmd, err := ParseCmd(`link "my buffer" "new buffer"`, cmdlist)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if cmd.From != "my buffer" {
+		t.Error("unable to parse compound")
+	}
+
+	cmd, err = ParseCmd(`foo bar`, cmdlist)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cmd.Args[0] != "bar" {
+		t.Error("unable to parse simple")
+	}
+
+	cmd, err = ParseCmd(`quit`, cmdlist)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cmd.Name != "quit" && cmd.From != "" {
+		t.Error("Unable to parse cmd with no args")
+	}
+}

--- a/fs/internal/command/parsectl_test.go
+++ b/fs/internal/command/parsectl_test.go
@@ -19,7 +19,7 @@ media:
 `
 
 func TestParse(t *testing.T) {
-	cmdlist, err := Parse([]byte(data))
+	cmdlist, err := ParseCtlFile([]byte(data))
 	if err != nil {
 		t.Error(err)
 		return

--- a/fs/internal/defaults/ctl.go
+++ b/fs/internal/defaults/ctl.go
@@ -72,7 +72,7 @@ func (c *Control) SetCommands(cmd ...*command.Command) error {
 }
 
 func (c *Control) BuildCommand(cmd string) (*command.Command, error) {
-	return command.BuildFrom(cmd, c.cmdlist)
+	return command.ParseCmd(cmd, c.cmdlist)
 }
 
 func (c *Control) Cleanup() {

--- a/fs/internal/mock/ctl.go
+++ b/fs/internal/mock/ctl.go
@@ -60,7 +60,7 @@ func (c *Control) SetCommands(cmd ...*command.Command) error {
 }
 
 func (c *Control) BuildCommand(cmd string) (*command.Command, error) {
-	return command.BuildFrom(cmd, c.cmdlist)
+	return command.ParseCmd(cmd, c.cmdlist)
 }
 
 func (c *Control) CreateBuffer(name, doctype string) error {
@@ -142,7 +142,7 @@ func (c *Control) pushTab(tabname, doctype string) error {
 }
 
 func (c *Control) Errorwriter() (*writer.WriteCloser, error) {
-	w := writer.New(c.Event, &tab{}, "errors")
+	w := writer.New(c.Event, os.Stdout, "errors")
 
 	return w, nil
 }


### PR DESCRIPTION
Parse in commands, send them to services as full commands that they can switch on
It will make creating a new service slightly easier.

Eventual work may be done to the parser to make it match a more idiomatic argument format, such as what is found in `man`. 