### PR TITLE
Tabs - add unread count

### DIFF
--- a/service/internal/files/feed.go
+++ b/service/internal/files/feed.go
@@ -9,15 +9,19 @@ import (
 )
 
 type FeedFile struct {
-	feed store.File
-	offset int64
+	act		func(string)
+	buffer	string
+	feed	store.File
+	offset	int64
 }
 
-func Feed(feed store.File, err error) (*FeedFile, error) {
+func Feed(feed store.File, act func(string), buffer string, err error) (*FeedFile, error) {
 	feed.Seek(0, io.SeekStart)
 	f := &FeedFile{
-		feed: feed,
-		offset: 0,
+		feed:	feed,
+		buffer: buffer,
+		act:	act,
+		offset:	0,
 	}
 	return f, err
 }
@@ -32,10 +36,12 @@ func (f *FeedFile) Read(b []byte) (n int, err error) {
 			time.Sleep(time.Second)
 			f.feed.Seek(f.offset, io.SeekStart)
 			if n > 0 {
+				f.act(f.buffer)
 				return len(b), nil
 			}
 			goto LOOP
 		case nil:
+			f.act(f.buffer)
 			return len(b), nil
 		default:
 			// Just exit the loop cleanly, as this can be a number of different errors depending on the backing store

--- a/service/internal/session/session.go
+++ b/service/internal/session/session.go
@@ -58,7 +58,8 @@ func (s *Session) Listen(debug bool) error {
 		s.Store = store.NewRamstore(debug)
 	}
 
-	s.Control = files.New(s.Store, debug)
+	filer := files.New(s.Store, debug)
+	s.Control = filer
 
 	// Set up commander
 	s.commander = &command.Command{
@@ -77,15 +78,14 @@ func (s *Session) Listen(debug bool) error {
 		if err != nil {
 			return err
 		}
-
 		s.Listener = listener
 	}
-
 	if e := s.Listener.Register(s.Store, s.commander, s.Callback); e != nil {
 		s.debug(sessionError, e)
 		return e
 	}
 
+	s.Listener.SetActivity(filer.Activity)
 	// Make sure our services are started
 	if svc, ok := s.Runner.(runner.Listener); ok {
 		go svc.Listen(s.Control)

--- a/service/listener/9p.go
+++ b/service/listener/9p.go
@@ -64,6 +64,10 @@ func (np Listen9p) Register(filer store.Filer, commander commander.Commander, ca
 	return np.session.Register(filer, commander, callback)
 }
 
+func (np Listen9p) SetActivity(act func(string)) {
+	np.session.SetActivity(act)
+}
+
 func (np Listen9p) Type() string {
 	return "9p"
 }

--- a/service/listener/listener.go
+++ b/service/listener/listener.go
@@ -15,6 +15,9 @@ type Listener interface {
 	Address() string
 	// Listen listens for client connections
 	Listen() error
+	// SetActivity is a callback used to notify when a client has read content from a particular buffer
+	// It shuold reset the unread count for that given buffer to zero
+	SetActivity(func(string))
 	// Register accepts a Storage, and associates a Filer datatset with the Listener session
 	// Additionally, a callback can be registered to allow on-connect/command information
 	Register(store.Filer, commander.Commander, callback.Callback) error


### PR DESCRIPTION
Closes #76 

This adds an unread count to the Tabs file, such as 
```
#mychannel [12]
```
On read from mychannel, it will update the count to reflect the unread lines. Currently, it zeroes it out but in future if seeks are wanted/needed, it can be modified.